### PR TITLE
Queue.queue() -> Queue->Queue()

### DIFF
--- a/skd_thread.py
+++ b/skd_thread.py
@@ -176,7 +176,7 @@ class KeyDist(object):
                 self.removeKeyOnExit.set()
             else:
                 logger.debug('requesting a permenant key passphrase')
-                queue=Queue.queue()
+                queue=Queue.Queue()
                 wx.CallAfter(self.getPassphrase,queue=queue)
                 (canceled,self.password)=queue.get()
                 if canceled:


### PR DESCRIPTION
This typo leads to errors ... In line 210 it is correct.
I honestly wonder why this ever worked.